### PR TITLE
Fix path handling (duplicate path element)

### DIFF
--- a/xtraplatform-core/xtraplatform-store/src/main/java/de/ii/xtraplatform/store/infra/BlobSourceFs.java
+++ b/xtraplatform-core/xtraplatform-store/src/main/java/de/ii/xtraplatform/store/infra/BlobSourceFs.java
@@ -85,7 +85,7 @@ public class BlobSourceFs implements BlobSource, BlobWriter, BlobLocals {
       return Stream.empty();
     }
 
-    Path dir = root.resolve(path);
+    Path dir = root.resolve(prefix.relativize(path));
     return Files.find(
             dir,
             maxDepth,


### PR DESCRIPTION
Without the change, the resulting path was `.../cache/tiles/tiles/...`