### PR TITLE
Log error, if entity creation fails

### DIFF
--- a/xtraplatform-core/xtraplatform-store/src/main/java/de/ii/xtraplatform/store/app/entities/EntityDataStoreImpl.java
+++ b/xtraplatform-core/xtraplatform-store/src/main/java/de/ii/xtraplatform/store/app/entities/EntityDataStoreImpl.java
@@ -393,6 +393,12 @@ public class EntityDataStoreImpl extends AbstractMergeableKeyValueStore<EntityDa
                 })
             .thenAccept(ignore -> CompletableFuture.completedFuture(null));
       } catch (Throwable e) {
+        if (LOGGER.isErrorEnabled()) {
+          LOGGER.error("Failed to create entity {}: {}", identifier, e.getMessage());
+          if (LOGGER.isDebugEnabled(MARKER.STACKTRACE)) {
+            LOGGER.debug(LogContext.MARKER.STACKTRACE, "Stacktrace: ", e);
+          }
+        }
         return CompletableFuture.completedFuture(null);
       }
     }

--- a/xtraplatform-core/xtraplatform-store/src/main/java/de/ii/xtraplatform/store/app/entities/EntityDataStoreImpl.java
+++ b/xtraplatform-core/xtraplatform-store/src/main/java/de/ii/xtraplatform/store/app/entities/EntityDataStoreImpl.java
@@ -393,12 +393,7 @@ public class EntityDataStoreImpl extends AbstractMergeableKeyValueStore<EntityDa
                 })
             .thenAccept(ignore -> CompletableFuture.completedFuture(null));
       } catch (Throwable e) {
-        if (LOGGER.isErrorEnabled()) {
-          LOGGER.error("Failed to create entity {}: {}", identifier, e.getMessage());
-          if (LOGGER.isDebugEnabled(MARKER.STACKTRACE)) {
-            LOGGER.debug(LogContext.MARKER.STACKTRACE, "Stacktrace: ", e);
-          }
-        }
+        LogContext.error(LOGGER, e, "Failed to create entity {}", identifier);
         return CompletableFuture.completedFuture(null);
       }
     }


### PR DESCRIPTION
It took me a while to figure out a problem in the tiles tests until I figured out that there was an issue in creating a tile provider entity during startup.