### PR TITLE
fix async startup of custom html resources

### DIFF
--- a/xtraplatform-web/src/main/java/de/ii/xtraplatform/web/app/BlobStoreMustacheResolver.java
+++ b/xtraplatform-web/src/main/java/de/ii/xtraplatform/web/app/BlobStoreMustacheResolver.java
@@ -49,11 +49,7 @@ public class BlobStoreMustacheResolver implements PartialMustacheResolver, AppLi
 
   @Override
   public CompletionStage<Void> onStart(boolean isStartupAsync) {
-    if (isStartupAsync) {
-      templateStore.onReady().thenRunAsync(this::init, Executors.newSingleThreadExecutor());
-    } else {
-      init();
-    }
+    templateStore.onReady().thenRunAsync(this::init, Executors.newSingleThreadExecutor()).join();
 
     return CompletableFuture.completedFuture(null);
   }


### PR DESCRIPTION
@azahnen 

The custom HTML templates/assets were ignored during async startup (at least in some cases), because the mustache resolver startup occurred before the resources store was ready. I have created a fix that works in my tests, but you should review this. 